### PR TITLE
Added Lato font source and acknowledgements

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
@@ -19,11 +20,17 @@
   <link rel="stylesheet" href="/public/css/custom.css">
   <link rel="stylesheet" href="/public/css/syntax.css">
   <link rel="stylesheet" href="/public/css/hyde.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC&display=swap" rel="stylesheet">
 
+  <!-- Fonts -->
+  <!-- This is the Site Name font -->
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <!-- This is for the nice sidebar icons -->
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">
+
+  <!-- Lato Font --> <!-- This is taken from Google Fonts. It's good practice to replace the following section whenever you change your main font (if it's from Google or somewhere else on the web) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet">
 
   <!-- Icons -->
   <!-- <link rel="apple-touch-icon" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon.png"> -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-
+<!-- This site was made using the Jekyll theme Hyde, with edits from James Leslie: https://github.com/jeslie0 -->
   {% include head.html %}
   <body class="theme-base-EXAMPLE">
 


### PR DESCRIPTION
This pull request (PR) should allow the font-family Lato to be used. The reason why it wasn't working is that unless one has the font Lato installed on their computer and accessible by a browser, it wouldn't show up. What I have done is add a source for the font in the _includes/head.html file, which will propagate throughout the whole site. This should allow the font to rendered as expected!

If you want to use a non-web-safe font (I think that is the correct term) then make sure to edit the head.html file to include a link. Google provides the required code for its fonts, so it can just be copied and pasted in.

I also added some acknowledgements to the source code.